### PR TITLE
Fix R_X86_64_32S relocation type

### DIFF
--- a/arch_x86.cpp
+++ b/arch_x86.cpp
@@ -4236,7 +4236,7 @@ public:
 				reloc.truncateSize = 2;
 				break;
 			case R_X86_64_32S:
-				reloc.pcRelative = true;
+				reloc.pcRelative = false;
 				reloc.baseRelative = false;
 				reloc.hasSign = true;
 				reloc.size = 4;


### PR DESCRIPTION
Should not have been pc-relative.