### PR TITLE
Use ZMM0 as x64 floating point return register

### DIFF
--- a/arch_x86.cpp
+++ b/arch_x86.cpp
@@ -3809,7 +3809,7 @@ public:
 
 	virtual uint32_t GetFloatReturnValueRegister() override
 	{
-		return XED_REG_XMM0;
+		return XED_REG_ZMM0;
 	}
 
 	virtual RegisterValue GetIncomingFlagValue(uint32_t flag, Function*) override


### PR DESCRIPTION
XMM0 is technically correct according to the ABI, but the BN core does not like Return Value Registers to be partial regs.