### PR TITLE
Better flag lifting for vectorized/FP operations

### DIFF
--- a/arch_x86.cpp
+++ b/arch_x86.cpp
@@ -2107,11 +2107,15 @@ size_t X86CommonArchitecture::GetFlagWriteLowLevelIL(BNLowLevelILOperation op, s
 		}
 		break;
 	case LLIL_XOR:
+	case LLIL_AND:
+	case LLIL_OR:
 		switch (flag)
 		{
 		case IL_FLAG_C:
 		case IL_FLAG_O:
 			return il.Const(0, 0);
+		case IL_FLAG_A:
+			return il.Undefined();
 		}
 		break;
 	case LLIL_MULU_DP:

--- a/il.cpp
+++ b/il.cpp
@@ -709,7 +709,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 				il.And(opOneLen,
 					ReadILOperand(il, xedd, addr, 1, 1),
 					ReadILOperand(il, xedd, addr, 2, 2),
-				IL_FLAGWRITE_ALL)));
+				0))); // VPAND doesn't modify any flag
 		break;
 
 	case XED_ICLASS_ANDN:
@@ -2631,13 +2631,20 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 
 	case XED_ICLASS_OR_LOCK: // TODO: Handle lock prefix
 	case XED_ICLASS_OR:
+		il.AddInstruction(
+			WriteILOperand(il, xedd, addr, 0, 0,
+				il.Or(opOneLen,
+					ReadILOperand(il, xedd, addr, 0, 0),
+					ReadILOperand(il, xedd, addr, 1, 1),
+				IL_FLAGWRITE_ALL)));
+		break;
 	case XED_ICLASS_POR:
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
 			il.Or(opOneLen,
 				ReadILOperand(il, xedd, addr, 0, 0),
 				ReadILOperand(il, xedd, addr, 1, 1),
-			IL_FLAGWRITE_ALL)));
+			0))); // POR doesn't modify any flag
 		break;
 	case XED_ICLASS_VPOR:
 		if (xed_classify_avx512(xedd))
@@ -2650,7 +2657,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 			il.Or(opOneLen,
 				ReadILOperand(il, xedd, addr, 1, 1),
 				ReadILOperand(il, xedd, addr, 2, 2),
-			IL_FLAGWRITE_ALL)));
+			0))); // VPOR doesn't modify flags
 		break;
 
 	case XED_ICLASS_POP:

--- a/il.cpp
+++ b/il.cpp
@@ -2899,12 +2899,18 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 
 	case XED_ICLASS_SBB_LOCK: // TODO: Handle lock prefix
 	case XED_ICLASS_SBB:
+		// SBB can be translated as DEST := (DEST - (SRC + CF));
+		// Sets the flags accordingly to the operations.
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
-				il.SubBorrow(opOneLen,
+				il.Sub(opOneLen,
 					ReadILOperand(il, xedd, addr, 0, 0),
-					ReadILOperand(il, xedd, addr, 1, 1),
-				il.Flag(IL_FLAG_C), IL_FLAGWRITE_ALL)));
+					il.Add(opTwoLen,
+						ReadILOperand(il, xedd, addr, 1, 1),
+						il.Flag(IL_FLAG_C),
+						IL_FLAGWRITE_ALL),
+				IL_FLAGWRITE_ALL)));
+
 		break;
 
 	case XED_ICLASS_REPE_SCASB:

--- a/il.cpp
+++ b/il.cpp
@@ -674,9 +674,6 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 					ReadILOperand(il, xedd, addr, 0, 0),
 					ReadILOperand(il, xedd, addr, 1, 1),
 					IL_FLAGWRITE_ALL)));
-		il.AddInstruction(il.SetFlag(IL_FLAG_C, il.Const(1, 0)));
-		il.AddInstruction(il.SetFlag(IL_FLAG_O, il.Const(1, 0)));
-		il.AddInstruction(il.SetFlag(IL_FLAG_A, il.Undefined()));
 		break;
 	case XED_ICLASS_PAND:
 		il.AddInstruction(
@@ -2630,9 +2627,6 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 					ReadILOperand(il, xedd, addr, 0, 0),
 					ReadILOperand(il, xedd, addr, 1, 1),
 				IL_FLAGWRITE_ALL)));
-		il.AddInstruction(il.SetFlag(IL_FLAG_C, il.Const(1, 0)));
-		il.AddInstruction(il.SetFlag(IL_FLAG_O, il.Const(1, 0)));
-		il.AddInstruction(il.SetFlag(IL_FLAG_A, il.Undefined()));
 		break;
 	case XED_ICLASS_POR:
 		il.AddInstruction(
@@ -3838,8 +3832,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 					opOneLen,
 					ReadFloatILOperand(il, xedd, addr, 0, 0),
 					ReadFloatILOperand(il, xedd, addr, 1, 1)
-				),
-				0 // Don't modify any flags
+				)
 			)
 		);
 		ExprId set_zero_flag_insn = il.SetFlag(IL_FLAG_Z,
@@ -3854,8 +3847,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 					opOneLen,
 					ReadFloatILOperand(il, xedd, addr, 0, 0),
 					ReadFloatILOperand(il, xedd, addr, 1, 1)
-				),
-				0 // Don't modify any flags
+				)
 			)
 		);
 		il.AddInstruction(set_parity_flag_expr);

--- a/il.cpp
+++ b/il.cpp
@@ -3382,11 +3382,17 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 
 		break;
 	}
-
-	case XED_ICLASS_XOR_LOCK: // TODO: Handle lock prefix
 	case XED_ICLASS_XORPS:
-	case XED_ICLASS_XOR:
 	case XED_ICLASS_PXOR:
+		il.AddInstruction(
+			WriteILOperand(il, xedd, addr, 0, 0,
+				il.Xor(opOneLen,
+					ReadILOperand(il, xedd, addr, 0, 0),
+					ReadILOperand(il, xedd, addr, 1, 1),
+					0)));
+		break;
+	case XED_ICLASS_XOR_LOCK: // TODO: Handle lock prefix
+	case XED_ICLASS_XOR:
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
 				il.Xor(opOneLen,
@@ -3405,7 +3411,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 				il.Xor(opOneLen,
 					ReadILOperand(il, xedd, addr, 1, 1),
 					ReadILOperand(il, xedd, addr, 2, 2),
-				IL_FLAGWRITE_ALL)));
+				0)));
 		break;
 
 	case XED_ICLASS_XADD:

--- a/il.cpp
+++ b/il.cpp
@@ -668,13 +668,39 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 
 	case XED_ICLASS_AND_LOCK: // TODO: Add Lock construct
 	case XED_ICLASS_AND:
+		il.AddInstruction(
+			WriteILOperand(il, xedd, addr, 0, 0,
+				il.And(opOneLen,
+					ReadILOperand(il, xedd, addr, 0, 0),
+					ReadILOperand(il, xedd, addr, 1, 1),
+					IL_FLAGWRITE_ALL)));
+		// Setting parity flag.
+		// Basically, if the result of AND sets the LSB, the
+		// parity flag will be unset.
+		il.AddInstruction(
+			il.SetFlag(IL_FLAG_P,
+				il.Not(
+					1,
+					il.TestBit(
+						opOneLen,
+						il.And(
+							opOneLen,
+							ReadILOperand(il, xedd, addr, 0, 0),
+							ReadILOperand(il, xedd, addr, 1, 1)
+						),
+						il.Const(opOneLen, 0)
+					)
+				)
+			)
+		);
+		break;
 	case XED_ICLASS_PAND:
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
 				il.And(opOneLen,
 					ReadILOperand(il, xedd, addr, 0, 0),
 					ReadILOperand(il, xedd, addr, 1, 1),
-				IL_FLAGWRITE_ALL)));
+				0))); // PAND doesn't modify any flag.
 		break;
 
 	case XED_ICLASS_VPAND:

--- a/il.cpp
+++ b/il.cpp
@@ -674,25 +674,6 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 					ReadILOperand(il, xedd, addr, 0, 0),
 					ReadILOperand(il, xedd, addr, 1, 1),
 					IL_FLAGWRITE_ALL)));
-		// Setting parity flag.
-		// Basically, if the result of AND sets the LSB, the
-		// parity flag will be unset.
-		il.AddInstruction(
-			il.SetFlag(IL_FLAG_P,
-				il.Not(
-					1,
-					il.TestBit(
-						opOneLen,
-						il.And(
-							opOneLen,
-							ReadILOperand(il, xedd, addr, 0, 0),
-							ReadILOperand(il, xedd, addr, 1, 1)
-						),
-						il.Const(opOneLen, 0)
-					)
-				)
-			)
-		);
 		break;
 	case XED_ICLASS_PAND:
 		il.AddInstruction(
@@ -713,6 +694,16 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 		break;
 
 	case XED_ICLASS_ANDN:
+		il.AddInstruction(
+			WriteILOperand(il, xedd, addr, 0, 0,
+				il.And(opOneLen,
+					ReadILOperand(il, xedd, addr, 0, 0),
+					il.Not(
+						opTwoLen,
+						ReadILOperand(il, xedd, addr, 1, 1)
+					),
+					IL_FLAGWRITE_ALL)));
+		break;
 	case XED_ICLASS_PANDN:
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
@@ -722,9 +713,8 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 						opTwoLen,
 						ReadILOperand(il, xedd, addr, 1, 1)
 					),
-				IL_FLAGWRITE_ALL)));
+					0))); // Does not affect flags
 		break;
-
 	case XED_ICLASS_VPANDN:
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,

--- a/il.cpp
+++ b/il.cpp
@@ -674,6 +674,9 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 					ReadILOperand(il, xedd, addr, 0, 0),
 					ReadILOperand(il, xedd, addr, 1, 1),
 					IL_FLAGWRITE_ALL)));
+		il.AddInstruction(il.SetFlag(IL_FLAG_C, il.Const(1, 0)));
+		il.AddInstruction(il.SetFlag(IL_FLAG_O, il.Const(1, 0)));
+		il.AddInstruction(il.SetFlag(IL_FLAG_A, il.Undefined()));
 		break;
 	case XED_ICLASS_PAND:
 		il.AddInstruction(
@@ -2627,6 +2630,9 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 					ReadILOperand(il, xedd, addr, 0, 0),
 					ReadILOperand(il, xedd, addr, 1, 1),
 				IL_FLAGWRITE_ALL)));
+		il.AddInstruction(il.SetFlag(IL_FLAG_C, il.Const(1, 0)));
+		il.AddInstruction(il.SetFlag(IL_FLAG_O, il.Const(1, 0)));
+		il.AddInstruction(il.SetFlag(IL_FLAG_A, il.Undefined()));
 		break;
 	case XED_ICLASS_POR:
 		il.AddInstruction(


### PR DESCRIPTION
This PR does a few things:

- It implements `UCOMISD/COMISD/UCOMISS/COMISS` appropriate flag generation. You could see some invalid lifted code if it included some FP comparisons. I've made the decision to include the `is_unordered` call as well. It can be optimized out in the optimization pipeline if needed, but I liked having a high fidelity IL. In comparison, HexRays just assumes the comparison is never unordered and sets the parity flag to 0, always. Which works in _most_ cases. For testing, you can use
[adder.zip](https://github.com/Vector35/arch-x86/files/7831685/adder.zip). The source code for this is available [here](https://gist.github.com/ek0/a7f9bf7805874ab33ec1211333c2d5a0). There's a `test_double_comisd` function you can lift. Additionally, any `d3dcompiler.dll` contains plenty of these instructions :)
- It fixes the flag generation for the `sbb` instruction. I know you have a `SubBurrow` instruction in your IL but the Intel documentation describes the `sbb` instruction as `DEST := (DEST - (SRC + CF));` and the flags are evaluated as if it was a simple `sub` instruction. So I've just changed the lifting to represent this operation as the flags are already defined for `Sub`.
- It fixes flag generation for vectorized `OR/AND/XOR/ANDN` as these instructions do not modify them, as stated in the Intel manual.