### PR TITLE
Fix SHL invalid condition checking for null count

### DIFF
--- a/il.cpp
+++ b/il.cpp
@@ -3364,7 +3364,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 		// If the masked count is 0, the flags are not affected.
 		il.AddInstruction(
 			il.If(
-				il.CompareEqual(1,
+				il.CompareNotEqual(1,
 					il.And(1, ReadILOperand(il, xedd, addr, 1, 1), il.Const(1, count_mask)),
 					il.Const(1, 0)),
 				trueLabel,


### PR DESCRIPTION
This fixes https://github.com/Vector35/binaryninja-api/issues/2868 the condition checking the no-operation was the opposite of what it should've been due to a typo.

Here's the result:
![image](https://user-images.githubusercontent.com/7302683/150810149-e5a57c7b-78a4-482b-8097-34985482b4b1.png)
