### PR TITLE
Fix X86_64_RELOC_UNSIGNED not handling external symbols

### DIFF
--- a/arch_x86.cpp
+++ b/arch_x86.cpp
@@ -4187,14 +4187,11 @@ public:
 			dest32[0] = dest32[0] + target - (uint32_t)pcRelAddr;
 			break;
 		case X86_64_RELOC_UNSIGNED:
-			if (!info.external)
+			switch (info.size)
 			{
-				switch (info.size)
-				{
-					case 4: *dest32 += target - (uint32_t)pcRelAddr; break;
-					case 8: *dest64 += info.target - pcRelAddr; break;
-					default: break;
-				}
+				case 4: *dest32 += target - (uint32_t)pcRelAddr; break;
+				case 8: *dest64 += info.target - pcRelAddr; break;
+				default: break;
 			}
 			// TODO rebasing
 			break;


### PR DESCRIPTION
This was causing external symbol references in i.e data sections being null