### PR TITLE
Fix mismatching operand size when lifting `movd/movq/vmovd/vmovq` instructions

### DIFF
--- a/il.cpp
+++ b/il.cpp
@@ -2110,7 +2110,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 	case XED_ICLASS_MOVDIR64B:
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
-				ReadILOperand(il, xedd, addr, 1, 1)));
+				ReadILOperand(il, xedd, addr, 1, 1, opOneLen)));
 		break;
 
 	case XED_ICLASS_MOVSX:

--- a/test_lifting.py
+++ b/test_lifting.py
@@ -26,9 +26,15 @@ tests_basics = [
     (b'\x90', 'LLIL_NOP()')
 ]
 
+tests_movd = [
+    # vmovd eax, xmm0
+    (b'\xC5\xF9\x7E\xC0', 'LLIL_SET_REG.d(eax,LLIL_REG.d(xmm0))'),
+]
+
 test_cases = \
     tests_interrupts + \
-    tests_basics
+    tests_basics + \
+    tests_movd
 
 import re
 import sys


### PR DESCRIPTION
Prior to this fix `movd eax, xmm0` was lifted to `eax = xmm0` instead of `eax = xmm0.d`.
In SSA form, this resulted in a semantically invalid zero-extend instruction that made no sense: `rax#1 = zx.q(zmm0.xmm0)`, which is wrong since `xmm0` is bigger than a quad-word.

Fixed by specifying the explicit size of the source operand:
https://github.com/Vector35/arch-x86/blob/a87d5df489eed969dec7f36235ebd81c3ff87acb/il.cpp#L2104-L2115